### PR TITLE
Add DeepSeek chat API client with retries

### DIFF
--- a/shared/adapters/deepseek.py
+++ b/shared/adapters/deepseek.py
@@ -1,0 +1,42 @@
+import asyncio
+import random
+from typing import Any
+
+import httpx
+import tiktoken
+
+from shared.models.errors import LLMApiError
+
+API_URL = "https://api.deepseek.com/chat/completions"
+TOKEN_LIMIT = 64_000
+ENCODING = tiktoken.get_encoding("cl100k_base")
+
+
+async def deepseek_chat(
+    messages: list[dict], model: str = "deepseek-chat-v3-0324", **kwargs: Any
+) -> dict:
+    token_count = sum(len(ENCODING.encode(m.get("content", ""))) for m in messages)  # noqa: E501
+    if token_count > TOKEN_LIMIT:
+        raise ValueError("input exceeds 64k token limit")
+
+    payload = {"model": model, "messages": messages, **kwargs}
+    max_retries = 4
+
+    for attempt in range(max_retries + 1):
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(API_URL, json=payload)
+            if 200 <= resp.status_code < 300:
+                return resp.json()
+            if 400 <= resp.status_code < 500:
+                raise LLMApiError(code=resp.status_code, message=resp.text)
+            # 5xx
+            if attempt == max_retries:
+                raise LLMApiError(code=resp.status_code, message=resp.text)
+        except httpx.HTTPError as e:
+            if attempt == max_retries:
+                raise LLMApiError(code=0, message=str(e))
+        wait = random.uniform(0, 2**attempt)
+        await asyncio.sleep(wait)
+
+    raise LLMApiError(code=0, message="unknown error")

--- a/shared/models/errors.py
+++ b/shared/models/errors.py
@@ -1,0 +1,8 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class LLMApiError(Exception):
+    code: int
+    message: str
+    vendor: str = "deepseek"

--- a/tests/test_deepseek.py
+++ b/tests/test_deepseek.py
@@ -1,0 +1,94 @@
+import asyncio
+import importlib
+
+import httpx
+import pytest
+import tiktoken
+
+from shared.models.errors import LLMApiError
+
+
+class DummyEncoding:
+    def encode(self, text: str):
+        return list(text)
+
+
+@pytest.fixture(autouse=True)
+def _mock_tiktoken(monkeypatch):
+    monkeypatch.setattr(tiktoken, "get_encoding", lambda name: DummyEncoding())
+    import shared.adapters.deepseek as ds
+
+    importlib.reload(ds)
+    return ds.deepseek_chat
+
+
+class DummyClient:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.calls = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def post(self, url, json=None):
+        self.calls += 1
+        resp = self.responses.pop(0)
+        if isinstance(resp, Exception):
+            raise resp
+        return resp
+
+
+@pytest.mark.asyncio
+async def test_deepseek_chat_success(monkeypatch, _mock_tiktoken):
+    deepseek_chat = _mock_tiktoken
+    responses = [httpx.Response(200, json={"ok": True})]
+    client = DummyClient(responses)
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **_: client)
+
+    result = await deepseek_chat([{"role": "user", "content": "hi"}])
+    assert result == {"ok": True}
+    assert client.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_deepseek_chat_client_error(monkeypatch, _mock_tiktoken):
+    deepseek_chat = _mock_tiktoken
+    responses = [httpx.Response(400, json={"error": "bad"})]
+    client = DummyClient(responses)
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **_: client)
+
+    with pytest.raises(LLMApiError) as exc:
+        await deepseek_chat([{"role": "user", "content": "hi"}])
+    assert exc.value.code == 400
+
+
+@pytest.mark.asyncio
+async def test_deepseek_chat_server_error_retries(monkeypatch, _mock_tiktoken):
+    deepseek_chat = _mock_tiktoken
+    responses = [httpx.Response(500, json={"error": "fail"}) for _ in range(5)]
+    client = DummyClient(responses)
+    monkeypatch.setattr(httpx, "AsyncClient", lambda **_: client)
+
+    sleeps = []
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(asyncio, "sleep", fake_sleep)
+
+    with pytest.raises(LLMApiError) as exc:
+        await deepseek_chat([{"role": "user", "content": "hi"}])
+    assert exc.value.code == 500
+    assert len(sleeps) == 4
+    assert client.calls == 5
+
+
+@pytest.mark.asyncio
+async def test_deepseek_chat_token_limit(monkeypatch, _mock_tiktoken):
+    deepseek_chat = _mock_tiktoken
+    over_limit = "a" * 65000
+    with pytest.raises(ValueError):
+        await deepseek_chat([{"role": "user", "content": over_limit}])


### PR DESCRIPTION
## Summary
- implement async DeepSeek Chat Completion wrapper with token limit and exponential backoff
- raise `LLMApiError` on API errors
- add unit tests for success, error handling, retries, and token limit

## Testing
- `flake8 shared/__init__.py shared/models/errors.py shared/adapters/deepseek.py tests/test_deepseek.py`
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b5e5580f88326b86fdfdbb10a98bd