### PR TITLE
Add LLM router with metrics and circuit breaker

### DIFF
--- a/shared/utils/llm_router.py
+++ b/shared/utils/llm_router.py
@@ -1,0 +1,61 @@
+import time
+from typing import Any
+
+from prometheus_client import Counter
+
+from shared.adapters.deepseek import deepseek_chat
+from shared.adapters.gemini import gemini_chat
+
+
+llm_calls_total = Counter("llm_calls_total", "Total number of LLM calls", ["vendor"])
+
+_BREAKER = {
+    "gemini": {"failures": 0, "until": 0.0},
+    "deepseek": {"failures": 0, "until": 0.0},
+}
+
+
+async def route_llm(
+    domain: str,
+    messages: list[dict],
+    ctx_tokens: int,
+    cost_sensitive: bool = False,
+) -> dict:
+    """Route request to an LLM provider based on heuristics with breaker."""
+    vendor: str
+    model: str | None = None
+
+    if ctx_tokens > 64000:
+        vendor = "gemini"
+    elif cost_sensitive or domain == "oncology_kb":
+        vendor = "deepseek"
+    else:
+        vendor = "gemini"
+        model = "gemini-1.5-flash"
+
+    now = time.monotonic()
+    state = _BREAKER[vendor]
+    if state["until"] > now:
+        vendor = "deepseek" if vendor == "gemini" else "gemini"
+        model = None
+        state = _BREAKER[vendor]
+
+    try:
+        if vendor == "gemini":
+            if model is None:
+                result = await gemini_chat(messages)
+            else:
+                result = await gemini_chat(messages, model=model)
+        else:
+            result = await deepseek_chat(messages)
+        state["failures"] = 0
+        return result
+    except Exception:
+        state["failures"] += 1
+        if state["failures"] >= 3:
+            state["until"] = time.monotonic() + 120
+            state["failures"] = 0
+        raise
+    finally:
+        llm_calls_total.labels(vendor=vendor).inc()
+

--- a/tests/test_router.py
+++ b/tests/test_router.py
@@ -1,0 +1,103 @@
+import importlib
+import types
+
+import pytest
+
+from shared.models.errors import LLMApiError
+
+
+class DummyCounterInstance:
+    def __init__(self, counts, vendor):
+        self.counts = counts
+        self.vendor = vendor
+
+    def inc(self):
+        self.counts[self.vendor] = self.counts.get(self.vendor, 0) + 1
+
+
+class DummyCounter:
+    def __init__(self):
+        self.counts = {}
+
+    def labels(self, vendor):
+        return DummyCounterInstance(self.counts, vendor)
+
+
+@pytest.fixture
+def router(monkeypatch):
+    dummy_counter = DummyCounter()
+    monkeypatch.setattr(
+        importlib.import_module("prometheus_client"), "Counter", lambda *a, **k: dummy_counter
+    )
+    module = importlib.reload(importlib.import_module("shared.utils.llm_router"))
+    return module, dummy_counter
+
+
+@pytest.mark.asyncio
+async def test_routing_rules(monkeypatch, router):
+    module, counter = router
+
+    async def fake_gemini(messages, model="gemini-1.5-pro"):
+        return {"vendor": "gemini", "model": model}
+
+    async def fake_deepseek(messages):
+        return {"vendor": "deepseek"}
+
+    monkeypatch.setattr(module, "gemini_chat", fake_gemini)
+    monkeypatch.setattr(module, "deepseek_chat", fake_deepseek)
+
+    res = await module.route_llm("general", [], 10)
+    assert res == {"vendor": "gemini", "model": "gemini-1.5-flash"}
+
+    res = await module.route_llm("general", [], 65000)
+    assert res == {"vendor": "gemini", "model": "gemini-1.5-pro"}
+
+    res = await module.route_llm("oncology_kb", [], 10)
+    assert res == {"vendor": "deepseek"}
+
+    res = await module.route_llm("general", [], 10, cost_sensitive=True)
+    assert res == {"vendor": "deepseek"}
+
+    assert counter.counts["gemini"] == 2
+    assert counter.counts["deepseek"] == 2
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker(monkeypatch, router):
+    module, counter = router
+
+    time_vals = [0]
+
+    def fake_monotonic():
+        return time_vals[0]
+
+    monkeypatch.setattr(module.time, "monotonic", fake_monotonic)
+
+    async def fail_gemini(messages, model="gemini-1.5-pro"):
+        raise LLMApiError(500, "fail", vendor="gemini")
+
+    async def ok_deepseek(messages):
+        return {"ok": True}
+
+    monkeypatch.setattr(module, "gemini_chat", fail_gemini)
+    monkeypatch.setattr(module, "deepseek_chat", ok_deepseek)
+
+    for _ in range(3):
+        with pytest.raises(LLMApiError):
+            await module.route_llm("general", [], 10)
+
+    assert module._BREAKER["gemini"]["until"] == pytest.approx(120)
+
+    res = await module.route_llm("general", [], 10)
+    assert res == {"ok": True}
+    assert counter.counts["deepseek"] == 1
+
+    time_vals[0] = 121
+    async def ok_gemini(messages, model="gemini-1.5-pro"):
+        return {"ok": "gemini"}
+
+    monkeypatch.setattr(module, "gemini_chat", ok_gemini)
+
+    res = await module.route_llm("general", [], 10)
+    assert res == {"ok": "gemini"}
+


### PR DESCRIPTION
## Summary
- implement `route_llm` for gemini/deepseek with routing logic
- add prometheus counter and circuit breaker
- test new router and breaker logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b641464c08326b23be08eb4594f96