### PR TITLE
Add error handling and MCP output models

### DIFF
--- a/shared/models/__init__.py
+++ b/shared/models/__init__.py
@@ -1,1 +1,18 @@
+"""Shared model exports."""
 
+from .errors import LLMApiError, BusinessError
+from .mcp_outputs import (
+    PsychologyResponse,
+    OncologyKBResponse,
+    RadiologyResponse,
+    VisionResponse,
+)
+
+__all__ = [
+    "LLMApiError",
+    "BusinessError",
+    "PsychologyResponse",
+    "OncologyKBResponse",
+    "RadiologyResponse",
+    "VisionResponse",
+]

--- a/shared/models/errors.py
+++ b/shared/models/errors.py
@@ -1,8 +1,38 @@
 from dataclasses import dataclass
+from fastapi.responses import JSONResponse
+
+
+@dataclass(init=False)
+class LLMApiError(Exception):
+    """Error returned by LLM providers."""
+
+    vendor: str
+    code: int
+    message: str
+    retriable: bool
+
+    def __init__(self, *args, **kwargs):
+        """Support both new and legacy initialization styles."""
+        if args and isinstance(args[0], int):
+            # legacy: LLMApiError(code, message, vendor="...", retriable=False)
+            self.code = args[0]
+            self.message = args[1] if len(args) > 1 else kwargs.get("message", "")
+            self.vendor = kwargs.get("vendor", "deepseek")
+            self.retriable = kwargs.get("retriable", False)
+        else:
+            # new: LLMApiError(vendor, code, message, retriable=False)
+            self.vendor = args[0] if args else kwargs.get("vendor", "deepseek")
+            self.code = args[1] if len(args) > 1 else kwargs.get("code", 0)
+            self.message = args[2] if len(args) > 2 else kwargs.get("message", "")
+            self.retriable = args[3] if len(args) > 3 else kwargs.get("retriable", False)
+        super().__init__(self.message)
 
 
 @dataclass
-class LLMApiError(Exception):
-    code: int
-    message: str
-    vendor: str = "deepseek"
+class BusinessError(Exception):
+    http_status: int
+    detail: str
+
+    def to_response(self) -> JSONResponse:
+        """Convert the error into a FastAPI JSON response."""
+        return JSONResponse(status_code=self.http_status, content={"detail": self.detail})

--- a/shared/models/mcp_outputs.py
+++ b/shared/models/mcp_outputs.py
@@ -1,0 +1,33 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class PsychologyResponse(BaseModel):
+    """Response schema for the Psychology MCP."""
+
+    result: str | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class OncologyKBResponse(BaseModel):
+    """Response schema for the OncologyKB MCP."""
+
+    result: str | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class RadiologyResponse(BaseModel):
+    """Response schema for the Radiology MCP."""
+
+    result: str | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+
+class VisionResponse(BaseModel):
+    """Response schema for the Vision MCP."""
+
+    result: str | None = None
+
+    model_config = ConfigDict(extra="forbid")


### PR DESCRIPTION
## Summary
- extend `LLMApiError` dataclass and keep backwards compatibility
- add `BusinessError` dataclass with `to_response` helper
- expose shared models
- define simple MCP output schemas using Pydantic v2

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b66a2c2888326a98eff1afb013301